### PR TITLE
CI: sync code & data > option to force app release

### DIFF
--- a/.github/workflows/mt-sync-code-data.yml
+++ b/.github/workflows/mt-sync-code-data.yml
@@ -50,11 +50,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: MT check if force app release true
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force-app-release == true }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force-app-release == 'true' }}
         run: |
           echo "it's TRUE"
       - name: MT check if force app release false
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force-app-release == false }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force-app-release == 'false' }}
         run: |
           echo "it's FALSE"
       - name: MT log inputs

--- a/.github/workflows/mt-sync-code-data.yml
+++ b/.github/workflows/mt-sync-code-data.yml
@@ -49,6 +49,12 @@ jobs:
     timeout-minutes: 90
     runs-on: ubuntu-latest
     steps:
+      - name: MT log inputs
+        run: |
+          echo "${{ github.event.inputs.force-app-release }}"
+          echo "${{ github.event.inputs.force-app-release == true }}"
+          echo "${{ github.event.inputs.force-app-release == false }}"
+          exit 1; # error # testing
       - name: MT check out main repository code (no submodules)
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/mt-sync-code-data.yml
+++ b/.github/workflows/mt-sync-code-data.yml
@@ -49,20 +49,6 @@ jobs:
     timeout-minutes: 90
     runs-on: ubuntu-latest
     steps:
-      - name: MT check if force app release true
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force-app-release == 'true' }}
-        run: |
-          echo "it's TRUE"
-      - name: MT check if force app release false
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force-app-release == 'false' }}
-        run: |
-          echo "it's FALSE"
-      - name: MT log inputs
-        run: |
-          echo "${{ github.event.inputs.force-app-release }}"
-          echo "${{ github.event.inputs.force-app-release == 'true' }}"
-          echo "${{ github.event.inputs.force-app-release == 'false' }}"
-          exit 1; # error # testing
       - name: MT check out main repository code (no submodules)
         uses: actions/checkout@v4
         with:
@@ -125,7 +111,7 @@ jobs:
       - name: MT set app release required (or not)
         run: ./set_app_release_required.sh
       - name: MT check if force app release
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force-app-release == true }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force-app-release == 'true' }}
         run: |
           MT_TEMP_DIR=".mt";
           mkdir -p $MT_TEMP_DIR;

--- a/.github/workflows/mt-sync-code-data.yml
+++ b/.github/workflows/mt-sync-code-data.yml
@@ -2,6 +2,12 @@
 name: MT sync code & data # download & parse
 on:
   workflow_dispatch: # manual
+    inputs:
+      force-app-release:
+        description: 'Force app release (even if no data change and latest release recent)'
+        type: boolean
+        default: false
+        required: false
   schedule:
     - cron: '0 12 * * 2' # Tuesdays @ 12pm UTC # WEEKLY https://crontab.guru/#0_12_*_*_2
 # gh workflow run mt-sync-code-data.yml --ref <branch>
@@ -104,6 +110,16 @@ jobs:
         run: ./commit_data_change.sh
       - name: MT set app release required (or not)
         run: ./set_app_release_required.sh
+      - name: MT check if force app release
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event.inputs.force-app-release == true }}
+        run: |
+          MT_TEMP_DIR=".mt";
+          mkdir -p $MT_TEMP_DIR;
+          MT_APP_RELEASE_REQUIRED_FILE="$MT_TEMP_DIR/mt_app_release_required";
+          MT_APP_RELEASE_REQUIRED=true;
+          echo "$MT_APP_RELEASE_REQUIRED" > $MT_APP_RELEASE_REQUIRED_FILE;
+          MT_SKIP_PUSH_COMMIT=false;
+          echo "MT_SKIP_PUSH_COMMIT=$MT_SKIP_PUSH_COMMIT" >> "$GITHUB_ENV";
       - name: MT assemble release (APK & ABB)
         run: ./assemble_release.sh
         env:

--- a/.github/workflows/mt-sync-code-data.yml
+++ b/.github/workflows/mt-sync-code-data.yml
@@ -52,8 +52,8 @@ jobs:
       - name: MT log inputs
         run: |
           echo "${{ github.event.inputs.force-app-release }}"
-          echo "${{ github.event.inputs.force-app-release == true }}"
-          echo "${{ github.event.inputs.force-app-release == false }}"
+          echo "${{ github.event.inputs.force-app-release == 'true' }}"
+          echo "${{ github.event.inputs.force-app-release == 'false' }}"
           exit 1; # error # testing
       - name: MT check out main repository code (no submodules)
         uses: actions/checkout@v4

--- a/.github/workflows/mt-sync-code-data.yml
+++ b/.github/workflows/mt-sync-code-data.yml
@@ -111,7 +111,7 @@ jobs:
       - name: MT set app release required (or not)
         run: ./set_app_release_required.sh
       - name: MT check if force app release
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event.inputs.force-app-release == true }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force-app-release == true }}
         run: |
           MT_TEMP_DIR=".mt";
           mkdir -p $MT_TEMP_DIR;

--- a/.github/workflows/mt-sync-code-data.yml
+++ b/.github/workflows/mt-sync-code-data.yml
@@ -49,6 +49,14 @@ jobs:
     timeout-minutes: 90
     runs-on: ubuntu-latest
     steps:
+      - name: MT check if force app release true
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force-app-release == true }}
+        run: |
+          echo "it's TRUE"
+      - name: MT check if force app release false
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force-app-release == false }}
+        run: |
+          echo "it's FALSE"
       - name: MT log inputs
         run: |
           echo "${{ github.event.inputs.force-app-release }}"


### PR DESCRIPTION
Testing:
- https://github.com/mtransitapps/commons/pull/359

```
gh workflow run mt-sync-code-data.yml --ref mm/ci_sync_code_force_app_release --field force-app-release=false
```